### PR TITLE
Some tips on losses

### DIFF
--- a/docs/losses.md
+++ b/docs/losses.md
@@ -18,7 +18,7 @@ custom_loss="saturation"
 
 > Default: `1`
 
-Creates a loss based on how colorful the image is, encourages the image to become more colorful.
+Creates a loss based on how colorful the image is, encourages the image to become more colorful. A negative value will reduce saturation.
 
 ![saturation](losses/saturation%20wpixel.png)
 
@@ -39,7 +39,7 @@ custom_loss="smoothness"
 custom_loss="symmetry"
 ```
 
-### `saturation_weight`
+### `symmetry_weight`
 
 > Default: `1`
 


### PR DESCRIPTION
Fixes a typo in symmetry_weight, and adds a comment about using saturation_weight to reduce saturation.